### PR TITLE
create working dir /var/lib/dsme

### DIFF
--- a/dsme/PKGBUILD
+++ b/dsme/PKGBUILD
@@ -49,6 +49,7 @@ package() {
     cd $pkgname-$pkgver
     make DESTDIR="$pkgdir/" install
 
+    mkdir -p $pkgdir/var/lib/dsme
     mkdir -p $pkgdir/usr/lib/systemd/system/
     cp $srcdir/dsme.service $pkgdir/usr/lib/systemd/system/
 #Remove tests


### PR DESCRIPTION
Try to fix following error message:
```
Dec 04 08:39:52 manjaro-arm DSME[3145]: alarmtracker: /var/lib/dsme/alarm_queue_status.tmp: can't open: No such file or directory
```