### PR TITLE
maliit-nemo-keyboard-git depends on glacier-settings-git

### DIFF
--- a/maliit-nemo-keyboard-git/PKGBUILD
+++ b/maliit-nemo-keyboard-git/PKGBUILD
@@ -8,14 +8,14 @@ _branch=master
 _gitname=$_basename
 pkgname=$_basename-git
 
-pkgver=0.99.2.r23.g72a02aa2
+pkgver=0.103.r1.ga7de3b05
 
 pkgrel=1
 pkgdesc="Contains the reference input method plugins, such as the Maliit Keyboard. "
 arch=('x86_64' 'aarch64')
 url="https://$_host/$_project/$_gitname#branch=$_branch"
 license=('BSD')
-depends=('maliit-framework')
+depends=('maliit-framework' 'glacier-settings-git')
 makedepends=('git' 'cmake')
 provides=("${pkgname%-git}")
 conflicts=("${pkgname%-git}")


### PR DESCRIPTION
without glacier-settings is shown following error message:
```
keyboardsettingsplugin.h:28: Error: Undefined interface
```