### PR TITLE
Revert "qt5-sensors-sensorfw to provide just libqtsensors plugin"

### DIFF
--- a/qt5-sensors-sensorfw/PKGBUILD
+++ b/qt5-sensors-sensorfw/PKGBUILD
@@ -4,15 +4,13 @@
 pkgname=qt5-sensors-sensorfw
 _basever=5.15.7
 pkgver=5.15.7
-pkgrel=1
+pkgrel=2
 _commit=5f1f73fdba8906f58c4554cbef9c1a72edcf0230
 arch=('x86_64' 'aarch64')
 url='https://www.qt.io'
 license=('GPL3' 'LGPL3' 'FDL' 'custom')
-pkgdesc='Provides access to sensor hardware and motion gesture recognition'
-conflicts=('qt5-sensors')
-provides=("qt5-sensors=$pkgver")
-depends=('qt5-base' 'sensorfw')
+pkgdesc='SensorFW plugin for qt5-sensors'
+depends=('sensorfw' 'qt5-sensors')
 makedepends=('qt5-declarative' 'git')
 optdepends=('qt5-declarative: QML bindings')
 groups=('qt' 'qt5')
@@ -20,26 +18,16 @@ _pkgfqn=qtsensors
 source=(git+https://invent.kde.org/qt/qt/$_pkgfqn#commit=$_commit)
 sha256sums=('SKIP')
 
-
-prepare() {
-  mkdir -p build
-}
-
 build() {
-  cd build
-
-  qmake CONFIG+=sensorfw ../${_pkgfqn}
+  cd qtsensors
+  qmake CONFIG+=sensorfw
+  cd src/plugins/sensors/sensorfw
+  qmake
   make
 }
 
 package() {
-  cd build
-  make INSTALL_ROOT="$pkgdir" install
-
-  # Drop QMAKE_PRL_BUILD_DIR because reference the build dir
-  find "$pkgdir/usr/lib" -type f -name '*.prl' \
-    -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
-
-  install -d "$pkgdir"/usr/share/licenses
-  ln -s /usr/share/licenses/qt5-base "$pkgdir"/usr/share/licenses/${pkgname}
+  cd qtsensors/src/plugins/sensors/sensorfw
+  mkdir -p $pkgdir/usr/lib/qt/plugins/sensors/
+  cp ../../../../plugins/sensors/libqtsensors_sensorfw.so $pkgdir/usr/lib/qt/plugins/sensors/
 }


### PR DESCRIPTION
This reverts commit 550c89a19808d4462e9da09068325805918aaf83.

I am sorry, correct version was in nemo-packiging not in nemo-ux