### PR TITLE
[mce] update to 1.115

### DIFF
--- a/mce/PKGBUILD
+++ b/mce/PKGBUILD
@@ -5,7 +5,7 @@
 # Maintainer: James Kittsmiller (AJSlye) <james@nulogicsystems.com>
 
 pkgname=mce
-pkgver=1.114.1
+pkgver=1.115.0
 pkgrel=1
 pkgdesc="Mode Control Entity for Nokia mobile computers"
 arch=('x86_64' 'aarch64')
@@ -24,7 +24,7 @@ source=("${url}/archive/refs/tags/$pkgver.tar.gz"
 	"https://github.com/sailfishos-mirror/dbus-glib/archive/d42176ae4763e5288ef37ea314fe58387faf2005.tar.gz"
 	'0001-charger-Add-pinephone-charger-detection.-Fixes-JB-49.patch'
 	'0002-Handle_KEY_WAKEUP.patch')
-sha256sums=('ff71379299145f80def08dea80b521dcde35bfdec271224c70cecc72d7f8abec'
+sha256sums=('4e312e071618ca786005bac19a105a9014b0439b43aae5532001780abe151b89'
 	'f4c28d4740ac90863082e81c869e5178d25238b179747984faf0509e40d1afef'
 	'8ed260853165760423b4c6764ae9fb129e0506403d070fced60f576d9185e5f4'
 	'595ddbfda22a802a47f0239b24f53a28aa785abe128ae56cfbdbcac0d0deae2d')


### PR DESCRIPTION
There were some issue with build settings:

Project ERROR: Library 'sensorfw' is not defined.

I am not sure how to fix this better