### PR TITLE
[usb-moded] init-done is now in glacier-wayland-session

### DIFF
--- a/usb-moded/PKGBUILD
+++ b/usb-moded/PKGBUILD
@@ -84,7 +84,6 @@ package() {
 #install systemd stuff
 	mkdir -p $pkgdir/usr/lib/systemd/system/basic.target.wants/
 	install -m 644 -D systemd/usb-moded.service $pkgdir/usr/lib/systemd/system/
-	sed -i "s#Type=notify#Type=notify\nExecStartPre=bash -c 'mkdir -p /run/systemd/boot-status; cut -d \" \" -f 1 < /proc/uptime > /run/systemd/boot-status/init-done'#g" $pkgdir/usr/lib/systemd/system/usb-moded.service
 	ln -s ../usb-moded.service $pkgdir/usr/lib/systemd/system/basic.target.wants/
 
 	mkdir -p $pkgdir/etc/modprobe.d


### PR DESCRIPTION
in https://github.com/nemomobile-ux/glacier-wayland-session/blob/master/rootdir/usr/lib/startup/init-done
added in https://github.com/nemomobile-ux/glacier-wayland-session/pull/5