### PR TITLE
Revert "[abseil-cpp] update to 20230125.1"

### DIFF
--- a/abseil-cpp/0002-abseil.patch
+++ b/abseil-cpp/0002-abseil.patch
@@ -1,0 +1,58 @@
+Patch-Source: https://github.com/void-linux/void-packages/blob/master/srcpkgs/mozc/patches/abseil.patch
+
+Ported from grpc's patches
+
+An all-in-one patch that fixes several issues:
+
+1) UnscaledCycleClock not fully implemented for ppc*-musl (disabled on musl)
+2) powerpc stacktrace implementation only works on glibc (disabled on musl)
+4) examine_stack.cpp makes glibc assumptions on powerpc (fixed)
+
+--- a/absl/base/internal/unscaledcycleclock.h
++++ b/absl/base/internal/unscaledcycleclock.h
+@@ -46,7 +46,8 @@
+ 
+ // The following platforms have an implementation of a hardware counter.
+ #if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__) || \
+-    defined(__powerpc__) || defined(__ppc__) || defined(__riscv) ||     \
++    defined(__riscv) ||     \
++    ((defined(__powerpc__) || defined(__ppc__)) && defined(__GLIBC__)) || \
+     defined(_M_IX86) || defined(_M_X64)
+ #define ABSL_HAVE_UNSCALED_CYCLECLOCK_IMPLEMENTATION 1
+ #else
+--- a/absl/debugging/internal/examine_stack.cc
++++ b/absl/debugging/internal/examine_stack.cc
+@@ -27,6 +27,10 @@
+ #include <csignal>
+ #include <cstdio>
+ 
++#if defined(__powerpc__)
++#include <asm/ptrace.h>
++#endif
++
+ #include "absl/base/attributes.h"
+ #include "absl/base/internal/raw_logging.h"
+ #include "absl/base/macros.h"
+@@ -63,8 +67,10 @@
+     return reinterpret_cast<void*>(context->uc_mcontext.pc);
+ #elif defined(__powerpc64__)
+     return reinterpret_cast<void*>(context->uc_mcontext.gp_regs[32]);
++#elif defined(__powerpc__) && defined(__GLIBC__)
++    return reinterpret_cast<void*>(context->uc_mcontext.regs->nip);
+ #elif defined(__powerpc__)
+-    return reinterpret_cast<void*>(context->uc_mcontext.uc_regs->gregs[32]);
++    return reinterpret_cast<void*>(((struct pt_regs *)context->uc_regs)->nip);
+ #elif defined(__riscv)
+     return reinterpret_cast<void*>(context->uc_mcontext.__gregs[REG_PC]);
+ #elif defined(__s390__) && !defined(__s390x__)
+--- a/absl/debugging/internal/stacktrace_config.h
++++ b/absl/debugging/internal/stacktrace_config.h
+@@ -59,7 +59,7 @@
+ #elif defined(__i386__) || defined(__x86_64__)
+ #define ABSL_STACKTRACE_INL_HEADER \
+   "absl/debugging/internal/stacktrace_x86-inl.inc"
+-#elif defined(__ppc__) || defined(__PPC__)
++#elif (defined(__ppc__) || defined(__PPC__)) && defined(__GLIBC__)
+ #define ABSL_STACKTRACE_INL_HEADER \
+   "absl/debugging/internal/stacktrace_powerpc-inl.inc"
+ #elif defined(__aarch64__)

--- a/abseil-cpp/PKGBUILD
+++ b/abseil-cpp/PKGBUILD
@@ -1,7 +1,7 @@
 # $Id$
 
 pkgname=abseil-cpp
-pkgver=20230125.1
+pkgver=20211102.0
 pkgrel=1
 pkgdesc="Abseil is an open-source collection of C++ code"
 arch=('x86_64' 'aarch64')
@@ -11,14 +11,17 @@ license=('Apache-2.0 License')
 makedepends=('git' 'cmake')
 source=("${url}/archive/$pkgver/abseil-cpp-$pkgver.tar.gz"
     '0001-Add-fPIC.patch'
+    '0002-abseil.patch'
 )
-sha256sums=('81311c17599b3712069ded20cca09a62ab0bf2a89dfa16993786c8782b7ed145'
+sha256sums=('dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4'
     '917df057c253c0edf5710ee21ed4dac8991eb3e1e8c447f48ea05de49e98b384'
-)
+    '1245cad28319ff8c58cf5625d6ba7d1347c65a4fbf1acc03fb7b05418816b5d6')
 
 prepare() {
+    ls -l
     cd "$srcdir/${pkgname}-${pkgver}"
     patch -p1 --input="${srcdir}/0001-Add-fPIC.patch"
+    patch -p1 --input="${srcdir}/0002-abseil.patch"
 }
 
 build() {


### PR DESCRIPTION
This reverts commit bfeffff4b692d1e16f2844908a053517d9c1d246.

The telepathy-ofono produces huge number of errors. Lets revert it for now and fix it later.